### PR TITLE
Update .ubiquity-os.config.yml

### DIFF
--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -73,7 +73,7 @@ priorityLabels: &priorityLabels
   - name: "Priority: 4 (Urgent)"
   - name: "Priority: 5 (Emergency)"
 
-# ALIASES FINISH
+# ALIASES END
 
 plugins:
   - uses:

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -17,7 +17,7 @@ boostedFalse: &boostedFalse
   countWords: true
 
 boostedTrue: &boostedTrue
-  score: 1
+  score: 5
   countWords: true
 
 tcrHtmlConfig: &tcrHtmlConfig

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -1,81 +1,133 @@
+# ALIASES START
+
+zeroTrue: &zeroTrue
+  score: 0
+  countWords: true
+
+zeroFalse: &zeroFalse
+  score: 0
+  countWords: false
+
+headingDefaults: &headingDefaults
+  score: 1
+  countWords: true
+
+boostedFalse: &boostedFalse
+  score: 1
+  countWords: true
+
+boostedTrue: &boostedTrue
+  score: 1
+  countWords: true
+
+tcrHtmlConfig: &tcrHtmlConfig
+  a: *boostedTrue
+  code: *boostedFalse
+  img: *boostedFalse
+  h1: *headingDefaults
+  h2: *headingDefaults
+  h3: *headingDefaults
+  h4: *headingDefaults
+  h5: *headingDefaults
+  h6: *headingDefaults
+  br: *zeroTrue
+  p: *zeroTrue
+  em: *zeroTrue
+  ul: *zeroTrue
+  td: *zeroTrue
+  hr: *zeroTrue
+  ol: *zeroTrue
+  pre: *zeroFalse
+  strong: *zeroFalse
+  blockquote: *zeroFalse
+  li:
+    score: 0.1
+    countWords: true
+
+allRoles: &allRoles
+  - collaborator
+  - contributor
+
+collaboratorOnly: &collaboratorOnly
+  - collaborator
+
+teamMembersOnly: &teamMembersOnly
+  - COLLABORATOR
+  - OWNER
+  - MEMBER
+  - ADMIN
+
+timeLabels: &timeLabels
+  - name: "Time: <15 Minutes"
+  - name: "Time: <1 Hour"
+  - name: "Time: <2 Hours"
+  - name: "Time: <4 Hours"
+  - name: "Time: <1 Day"
+  - name: "Time: <1 Week"
+
+priorityLabels: &priorityLabels
+  - name: "Priority: 0 (Regression)"
+  - name: "Priority: 1 (Normal)"
+  - name: "Priority: 2 (Medium)"
+  - name: "Priority: 3 (High)"
+  - name: "Priority: 4 (Urgent)"
+  - name: "Priority: 5 (Emergency)"
+
+# ALIASES FINISH
+
 plugins:
   - uses:
-    - plugin: https://ubiquity-os-command-start-stop-main.ubiquity.workers.dev
-      skipBotEvents: false
-      with:
-        reviewDelayTolerance: 3 Days
-        taskStaleTimeoutDuration: 30 Days
-        startRequiresWallet: true
-        maxConcurrentTasks:
-          collaborator: 2
-          contributor: 2
-        emptyWalletText: Please set your wallet address with the /wallet command first and try again.
-        rolesWithReviewAuthority:
-          - COLLABORATOR
-          - OWNER
-          - MEMBER
-          - ADMIN
-        requiredLabelsToStart:
-          - name: "Priority: 0 (Regression)"
-            allowedRoles:
-              - collaborator
-              - contributor
-          - name: "Priority: 1 (Normal)"
-            allowedRoles:
-              - collaborator
-              - contributor
-          - name: "Priority: 2 (Medium)"
-            allowedRoles:
-              - collaborator
-              - contributor
-          - name: "Priority: 3 (High)"
-            allowedRoles:
-              - collaborator
-          - name: "Priority: 4 (Urgent)"
-            allowedRoles:
-              - collaborator
-          - name: "Priority: 5 (Emergency)"
-            allowedRoles:
-              - collaborator
-
-  - uses:
-    - plugin: https://ubiquity-os-command-wallet-main.ubiquity.workers.dev
-      with:
-        registerWalletWithVerification: false
-
-  - uses:
-    - plugin: ubiquity-os-marketplace/command-ask@main
-      with:
-        model: anthropic/claude-3.5-sonnet
-        openAiBaseUrl: https://openrouter.ai/api/v1
-
-  - uses:
-    - plugin: https://ubiquity-os-command-query-user-main.ubiquity.workers.dev
-      with:
-        allowPublicQuery: true
-
-  - uses:
-    - plugin: ubiquity-os-marketplace/daemon-pricing@main
-      with:
-        labels:
-          time:
-            - name: "Time: <15 Minutes"
-            - name: "Time: <1 Hour"
-            - name: "Time: <2 Hours"
-            - name: "Time: <4 Hours"
-            - name: "Time: <1 Day"
-            - name: "Time: <1 Week"
-          priority:
+      - plugin: https://ubiquity-os-command-start-stop-main.ubiquity.workers.dev
+        skipBotEvents: false
+        with:
+          reviewDelayTolerance: 3 Days
+          taskStaleTimeoutDuration: 30 Days
+          startRequiresWallet: true
+          maxConcurrentTasks:
+            collaborator: 2
+            contributor: 2
+          emptyWalletText: "Please set your wallet address with the /wallet command first and try again."
+          rolesWithReviewAuthority: *teamMembersOnly
+          requiredLabelsToStart:
             - name: "Priority: 0 (Regression)"
+              allowedRoles: *allRoles
             - name: "Priority: 1 (Normal)"
+              allowedRoles: *allRoles
             - name: "Priority: 2 (Medium)"
+              allowedRoles: *allRoles
             - name: "Priority: 3 (High)"
+              allowedRoles: *collaboratorOnly
             - name: "Priority: 4 (Urgent)"
+              allowedRoles: *collaboratorOnly
             - name: "Priority: 5 (Emergency)"
-        basePriceMultiplier: 2
-        publicAccessControl:
-          setLabel: true
-          fundExternalClosedIssue: false
+              allowedRoles: *collaboratorOnly
+
+  - uses:
+      - plugin: https://ubiquity-os-command-wallet-main.ubiquity.workers.dev
+        with:
+          registerWalletWithVerification: false
+
+  - uses:
+      - plugin: ubiquity-os-marketplace/command-ask@main
+        with:
+          model: anthropic/claude-3.5-sonnet
+          openAiBaseUrl: https://openrouter.ai/api/v1
+
+  - uses:
+      - plugin: https://ubiquity-os-command-query-user-main.ubiquity.workers.dev
+        with:
+          allowPublicQuery: true
+
+  - uses:
+      - plugin: ubiquity-os-marketplace/daemon-pricing@main
+        with:
+          labels:
+            time: *timeLabels
+            priority: *priorityLabels
+          basePriceMultiplier: 2
+          publicAccessControl:
+            setLabel: true
+            fundExternalClosedIssue: false
 
   - skipBotEvents: false
     uses:
@@ -83,7 +135,7 @@ plugins:
         with:
           logLevel: debug
           evmNetworkId: 100
-          evmPrivateEncrypted: bd5AFnSCO6c5jJyPifpOfr5Zys29RE7SyXkEU3akT13RtGmYDrqGIGuvJQyH53HA5dIba7PL5bXfll0JebmwXYe5gHIXSGX80WuGMDHh0cFfeGjHhmUXe8kkZ1OT2De9qRpqejJcEzdfi-8XNAvP7cQu2Vt-7RNnPw
+          evmPrivateEncrypted: bd5AFnSCO6c5jJyPifpOfr5Zys29RE7SyT13RtGmYDrqGIGuvJQyH53HA5dIba7PL5bXfll0JebmwXYe5gHIXSGX80WuGMDHh0cFfeGjHhmUXe8kkZ1OT2De9qRpqejJcEzdfi-8XNAvP7cQu2Vt-7RNnPw
           incentives:
             contentEvaluator:
               enabled: true
@@ -96,278 +148,33 @@ plugins:
               multipliers:
                 - role:
                     - ISSUE_SPECIFICATION
-                  multiplier: 1
-                  rewards:
-                    wordValue: 0.1
-                    html:
-                      br:
-                        score: 0
-                        countWords: true
-                      code:
-                        score: 5
-                        countWords: false
-                      p:
-                        score: 0
-                        countWords: true
-                      em:
-                        score: 0
-                        countWords: true
-                      img:
-                        score: 5
-                        countWords: true
-                      strong:
-                        score: 0
-                        countWords: false
-                      blockquote:
-                        score: 0
-                        countWords: false
-                      h1:
-                        score: 1
-                        countWords: true
-                      h2:
-                        score: 1
-                        countWords: true
-                      h3:
-                        score: 1
-                        countWords: true
-                      h4:
-                        score: 1
-                        countWords: true
-                      h5:
-                        score: 1
-                        countWords: true
-                      h6:
-                        score: 1
-                        countWords: true
-                      a:
-                        score: 5
-                        countWords: true
-                      li:
-                        score: 0.1
-                        countWords: true
-                      ul:
-                        score: 0
-                        countWords: true
-                      td:
-                        score: 0
-                        countWords: true
-                      hr:
-                        score: 0
-                        countWords: true
-                      pre:
-                        score: 0
-                        countWords: false
-                      ol:
-                        score: 0
-                        countWords: true
-                - role:
                     - ISSUE_AUTHOR
                     - ISSUE_COLLABORATOR
                     - PULL_COLLABORATOR
+                    - PULL_SPECIFICATION
                   multiplier: 1
                   rewards:
                     wordValue: 0.1
-                    html:
-                      br:
-                        score: 0
-                        countWords: true
-                      code:
-                        score: 5
-                        countWords: false
-                      p:
-                        score: 0
-                        countWords: true
-                      em:
-                        score: 0
-                        countWords: true
-                      img:
-                        score: 5
-                        countWords: true
-                      strong:
-                        score: 0
-                        countWords: false
-                      blockquote:
-                        score: 0
-                        countWords: false
-                      h1:
-                        score: 1
-                        countWords: true
-                      h2:
-                        score: 1
-                        countWords: true
-                      h3:
-                        score: 1
-                        countWords: true
-                      h4:
-                        score: 1
-                        countWords: true
-                      h5:
-                        score: 1
-                        countWords: true
-                      h6:
-                        score: 1
-                        countWords: true
-                      a:
-                        score: 5
-                        countWords: true
-                      li:
-                        score: 0.5
-                        countWords: true
-                      ul:
-                        score: 0
-                        countWords: true
-                      td:
-                        score: 0
-                        countWords: true
-                      hr:
-                        score: 0
-                        countWords: true
-                      pre:
-                        score: 0
-                        countWords: false
-                      ol:
-                        score: 0
-                        countWords: true
+                    html: *tcrHtmlConfig
                 - role:
                     - ISSUE_CONTRIBUTOR
                     - ISSUE_ASSIGNEE
                   multiplier: 0.25
                   rewards:
                     wordValue: 0.1
-                    html:
-                      br:
-                        score: 0
-                        countWords: true
-                      code:
-                        score: 5
-                        countWords: false
-                      p:
-                        score: 0
-                        countWords: true
-                      em:
-                        score: 0
-                        countWords: true
-                      img:
-                        score: 5
-                        countWords: true
-                      strong:
-                        score: 0
-                        countWords: false
-                      blockquote:
-                        score: 0
-                        countWords: false
-                      h1:
-                        score: 1
-                        countWords: true
-                      h2:
-                        score: 1
-                        countWords: true
-                      h3:
-                        score: 1
-                        countWords: true
-                      h4:
-                        score: 1
-                        countWords: true
-                      h5:
-                        score: 1
-                        countWords: true
-                      h6:
-                        score: 1
-                        countWords: true
-                      a:
-                        score: 5
-                        countWords: true
-                      li:
-                        score: 0.5
-                        countWords: true
-                      ul:
-                        score: 0
-                        countWords: true
-                      td:
-                        score: 0
-                        countWords: true
-                      hr:
-                        score: 0
-                        countWords: true
-                      pre:
-                        score: 0
-                        countWords: false
-                      ol:
-                        score: 0
-                        countWords: true
+                    html: *tcrHtmlConfig
                 - role:
-                    - PULL_SPECIFICATION
                     - PULL_AUTHOR
                     - PULL_CONTRIBUTOR
                     - PULL_ASSIGNEE
                   multiplier: 0
                   rewards:
                     wordValue: 0
-                    html:
-                      br:
-                        score: 0
-                        countWords: true
-                      code:
-                        score: 5
-                        countWords: false
-                      p:
-                        score: 0
-                        countWords: true
-                      em:
-                        score: 0
-                        countWords: true
-                      img:
-                        score: 5
-                        countWords: true
-                      strong:
-                        score: 0
-                        countWords: false
-                      blockquote:
-                        score: 0
-                        countWords: false
-                      h1:
-                        score: 1
-                        countWords: true
-                      h2:
-                        score: 1
-                        countWords: true
-                      h3:
-                        score: 1
-                        countWords: true
-                      h4:
-                        score: 1
-                        countWords: true
-                      h5:
-                        score: 1
-                        countWords: true
-                      h6:
-                        score: 1
-                        countWords: true
-                      a:
-                        score: 5
-                        countWords: true
-                      li:
-                        score: 0.1
-                        countWords: true
-                      ul:
-                        score: 0
-                        countWords: true
-                      td:
-                        score: 0
-                        countWords: true
-                      hr:
-                        score: 0
-                        countWords: true
-                      pre:
-                        score: 0
-                        countWords: false
-                      ol:
-                        score: 0
-                        countWords: true
-            permitGeneration: {}
-            githubComment:
-              post: true
-              debug: false
+                    html: *tcrHtmlConfig
+          permitGeneration: {}
+          githubComment:
+            post: true
+            debug: false
 
   - skipBotEvents: false
     uses:

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -14,7 +14,7 @@ headingDefaults: &headingDefaults
 
 boostedFalse: &boostedFalse
   score: 5
-  countWords: true
+  countWords: false
 
 boostedTrue: &boostedTrue
   score: 5

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -13,7 +13,7 @@ headingDefaults: &headingDefaults
   countWords: true
 
 boostedFalse: &boostedFalse
-  score: 1
+  score: 5
   countWords: true
 
 boostedTrue: &boostedTrue

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -1,79 +1,82 @@
 plugins:
   - uses:
-      - plugin: https://ubiquity-os-command-start-stop-main.ubiquity.workers.dev
-        skipBotEvents: false
-        with:
-          reviewDelayTolerance: 3 Days
-          taskStaleTimeoutDuration: 30 Days
-          startRequiresWallet: true
-          maxConcurrentTasks:
-            collaborator: 2
-            contributor: 2
-          emptyWalletText: Please set your wallet address with the /wallet command first
-            and try again.
-          rolesWithReviewAuthority:
-            - COLLABORATOR
-            - OWNER
-            - MEMBER
-            - ADMIN
-          requiredLabelsToStart:
+    - plugin: https://ubiquity-os-command-start-stop-main.ubiquity.workers.dev
+      skipBotEvents: false
+      with:
+        reviewDelayTolerance: 3 Days
+        taskStaleTimeoutDuration: 30 Days
+        startRequiresWallet: true
+        maxConcurrentTasks:
+          collaborator: 2
+          contributor: 2
+        emptyWalletText: Please set your wallet address with the /wallet command first and try again.
+        rolesWithReviewAuthority:
+          - COLLABORATOR
+          - OWNER
+          - MEMBER
+          - ADMIN
+        requiredLabelsToStart:
+          - name: "Priority: 0 (Regression)"
+            allowedRoles:
+              - collaborator
+              - contributor
+          - name: "Priority: 1 (Normal)"
+            allowedRoles:
+              - collaborator
+              - contributor
+          - name: "Priority: 2 (Medium)"
+            allowedRoles:
+              - collaborator
+              - contributor
+          - name: "Priority: 3 (High)"
+            allowedRoles:
+              - collaborator
+          - name: "Priority: 4 (Urgent)"
+            allowedRoles:
+              - collaborator
+          - name: "Priority: 5 (Emergency)"
+            allowedRoles:
+              - collaborator
+
+  - uses:
+    - plugin: https://ubiquity-os-command-wallet-main.ubiquity.workers.dev
+      with:
+        registerWalletWithVerification: false
+
+  - uses:
+    - plugin: ubiquity-os-marketplace/command-ask@main
+      with:
+        model: anthropic/claude-3.5-sonnet
+        openAiBaseUrl: https://openrouter.ai/api/v1
+
+  - uses:
+    - plugin: https://ubiquity-os-command-query-user-main.ubiquity.workers.dev
+      with:
+        allowPublicQuery: true
+
+  - uses:
+    - plugin: ubiquity-os-marketplace/daemon-pricing@main
+      with:
+        labels:
+          time:
+            - name: "Time: <15 Minutes"
+            - name: "Time: <1 Hour"
+            - name: "Time: <2 Hours"
+            - name: "Time: <4 Hours"
+            - name: "Time: <1 Day"
+            - name: "Time: <1 Week"
+          priority:
+            - name: "Priority: 0 (Regression)"
             - name: "Priority: 1 (Normal)"
-              allowedRoles: ['collaborator', 'contributor']          
             - name: "Priority: 2 (Medium)"
-              allowedRoles: ['collaborator', 'contributor']
             - name: "Priority: 3 (High)"
-              allowedRoles: ['collaborator']
             - name: "Priority: 4 (Urgent)"
-              allowedRoles: ['collaborator']
             - name: "Priority: 5 (Emergency)"
-              allowedRoles: ['collaborator']
-  - uses:
-      - plugin: https://ubiquity-os-command-wallet-main.ubiquity.workers.dev
-        with:
-          registerWalletWithVerification: false
-  - uses:
-      - plugin: ubiquity-os-marketplace/command-ask@main
-        with:
-          model: openai/o1-mini
-          openAiBaseUrl: https://openrouter.ai/api/v1
-  - uses:
-      - plugin: https://ubiquity-os-command-query-user-main.ubiquity.workers.dev
-        with:
-          allowPublicQuery: true
-  - uses:
-      - plugin: ubiquity-os-marketplace/daemon-pricing@main
-        with:
-          labels:
-            time:
-              - name: "Time: <15 Minutes"
-                collaboratorOnly: false
-              - name: "Time: <1 Hour"
-                collaboratorOnly: false
-              - name: "Time: <2 Hours"
-                collaboratorOnly: false
-              - name: "Time: <4 Hours"
-                collaboratorOnly: false
-              - name: "Time: <1 Day"
-                collaboratorOnly: false
-              - name: "Time: <1 Week"
-                collaboratorOnly: false
-            priority:
-              - name: "Priority: 0 (Regression)"
-                collaboratorOnly: false
-              - name: "Priority: 1 (Normal)"
-                collaboratorOnly: false
-              - name: "Priority: 2 (Medium)"
-                collaboratorOnly: false
-              - name: "Priority: 3 (High)"
-                collaboratorOnly: false
-              - name: "Priority: 4 (Urgent)"
-                collaboratorOnly: false
-              - name: "Priority: 5 (Emergency)"
-                collaboratorOnly: false
-          basePriceMultiplier: 2
-          publicAccessControl:
-            setLabel: true
-            fundExternalClosedIssue: false
+        basePriceMultiplier: 2
+        publicAccessControl:
+          setLabel: true
+          fundExternalClosedIssue: false
+
   - skipBotEvents: false
     uses:
       - plugin: ubiquity-os-marketplace/text-conversation-rewards@main
@@ -140,7 +143,7 @@ plugins:
                         score: 5
                         countWords: true
                       li:
-                        score: 0.5
+                        score: 0.1
                         countWords: true
                       ul:
                         score: 0
@@ -344,7 +347,7 @@ plugins:
                         score: 5
                         countWords: true
                       li:
-                        score: 0.5
+                        score: 0.1
                         countWords: true
                       ul:
                         score: 0
@@ -365,8 +368,8 @@ plugins:
             githubComment:
               post: true
               debug: false
+
   - skipBotEvents: false
-    testUbqKey: 1234
     uses:
       - plugin: ubiquity-os-marketplace/daemon-disqualifier@main
         skipBotEvents: false
@@ -379,13 +382,8 @@ plugins:
             - pull_request_review_comment.created
             - issue_comment.created
             - push
-          watch:
-            optOut:
-              - ubiquibot
-              - launch-party
-              - staging
-              - production
           disqualification: 14 days
+
   - uses:
       - plugin: ubiquity-os-marketplace/daemon-merging@main
         with:
@@ -395,22 +393,17 @@ plugins:
           mergeTimeout:
             collaborator: 3.5 days
             contributor: 7 days
-          repos:
-            monitor: []
-            ignore:
-              - ubiquibot
-              - launch-party
-              - staging
-              - production
           allowedReviewerRoles:
             - COLLABORATOR
             - MEMBER
             - OWNER
+
   - uses:
       - plugin: ubiquity-os-marketplace/text-vector-embeddings@main
         with:
           matchThreshold: 0.95
           warningThreshold: 0.75
           jobMatchingThreshold: 0.75
+
   - uses:
       - plugin: ubiquity-os-marketplace/daemon-pull-review@main

--- a/.github/.ubiquity-os.config.yml
+++ b/.github/.ubiquity-os.config.yml
@@ -135,7 +135,7 @@ plugins:
         with:
           logLevel: debug
           evmNetworkId: 100
-          evmPrivateEncrypted: bd5AFnSCO6c5jJyPifpOfr5Zys29RE7SyT13RtGmYDrqGIGuvJQyH53HA5dIba7PL5bXfll0JebmwXYe5gHIXSGX80WuGMDHh0cFfeGjHhmUXe8kkZ1OT2De9qRpqejJcEzdfi-8XNAvP7cQu2Vt-7RNnPw
+          evmPrivateEncrypted: bd5AFnSCO6c5jJyPifpOfr5Zys29RE7SyXkEU3akT13RtGmYDrqGIGuvJQyH53HA5dIba7PL5bXfll0JebmwXYe5gHIXSGX80WuGMDHh0cFfeGjHhmUXe8kkZ1OT2De9qRpqejJcEzdfi-8XNAvP7cQu2Vt-7RNnPw
           incentives:
             contentEvaluator:
               enabled: true


### PR DESCRIPTION
Makes use of aliases to dramatically shorten `text-conversation-rewards` configuration.

---
I noticed that `collaboratorOnly` is specified for `daemon-pricing`. Does this mean that only collaborators can set these labels? Contributors cannot set labels at all, which makes me wonder why we have this feature. The only way contributors can possibly set labels is if we have an issue template with it, but that is something we specificially need to go out of our way to set up so this is an unnecessary feature. https://github.com/ubiquity/.ubiquity-os/blob/development/.github/.ubiquity-os.config.yml#L49

---
```json
"collaboratorOnly": {
  "default": false,
  "description": "Whether the task is only available for collaborators to be assigned",
  "type": "boolean"
}
```

We also have `collaboratorOnly` for `command-start-stop`. So we should remove from `daemon-pricing`? https://github.com/ubiquity/.ubiquity-os/blob/development/.github/.ubiquity-os.config.yml#L19-L29

---
What is the purpose of `testUbqKey`? https://github.com/ubiquity/.ubiquity-os/blob/development/.github/.ubiquity-os.config.yml#L369

---
I’m also curious about the utility of `optOut`. Obviously I understand that it is a blacklist but why are we even blacklisting? https://github.com/ubiquity/.ubiquity-os/blob/development/.github/.ubiquity-os.config.yml#L382-L387